### PR TITLE
Add expose_host_agent formula

### DIFF
--- a/Formula/expose-host-agent.rb
+++ b/Formula/expose-host-agent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../lib/gc/github_private_release_download_strategy"
+
+class ExposeHostAgent < Formula
+  desc "Wrapper command that exposes your local SSH agent for use during docker builds"
+  homepage "https://github.com/gocardless/expose-host-agent"
+  url "git@github.com:gocardless/expose-host-agent.git", :using => GitDownloadStrategy, :ref_type => :tag, :revision => "v0.0.1"
+  version "0.0.1"
+  sha256 "44418172f3803a988c4c114989259ffa7087298203afb7b7a3277fc30c65bb99"
+
+  depends_on "socat"
+
+  def install
+    bin.install "bin/expose-host-agent"
+  end
+end


### PR DESCRIPTION
This commit adds a formula for the new expose-host-agent command. The
command allows you to run Docker builds that use the with-host-agent
script to download dependencies from private git repositories on your
Mac.

See also: `with-host-agent` in https://github.com/gocardless/base

This replaces #12.

Tested on my machine, naturally.