### PR TITLE
Pin versions of tools that we depend on

### DIFF
--- a/Formula/yq@2.4.1.rb
+++ b/Formula/yq@2.4.1.rb
@@ -1,0 +1,32 @@
+class YqAT241 < Formula
+  desc "Process YAML documents from the CLI"
+  homepage "https://github.com/mikefarah/yq"
+  url "https://github.com/mikefarah/yq/archive/v2.4.1.tar.gz"
+  sha256 "11fdf8269eb9eecd47398cb0d269a775492881ef53d880ef0d0e0daee26490d2"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "7eef86b614ab9695cb8ba108a659cba5cd504211b7236f8a561c7619aaf9b792" => :catalina
+    sha256 "5bf8a07349fcb306261676187d53d684cd14cfafead1a120a95a6318bb8beda9" => :mojave
+    sha256 "750248b8af5a72505593466f7add52fd6e20a2c2556dd7e28fc756420618680d" => :high_sierra
+  end
+
+  depends_on "go" => :build
+
+  conflicts_with "python-yq", :because => "both install `yq` executables"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/mikefarah/yq").install buildpath.children
+
+    cd "src/github.com/mikefarah/yq" do
+      system "go", "build", "-o", bin/"yq"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    assert_equal "key: cat", shell_output("#{bin}/yq n key cat").chomp
+    assert_equal "cat", pipe_output("#{bin}/yq r - key", "key: cat", 0).chomp
+  end
+end


### PR DESCRIPTION
This change pins the version of ``yq`` that we depend on for
our tooling to work as expected.

The main benefit of this is that when people do a `brew upgrade` they won't have to then selectively install a certain version.

To do this in the future for other tools:
```sh
brew extract --version <version> <formula> gocardless/taps
```