### PR TITLE
Add kubebuilder v2.3.1 with included assets for testing

### DIFF
--- a/Formula/kubebuilder.rb
+++ b/Formula/kubebuilder.rb
@@ -1,0 +1,25 @@
+class Kubebuilder < Formula
+  desc "SDK for building Kubernetes APIs using CRDs"
+  homepage "https://github.com/kubernetes-sigs/kubebuilder"
+  version "2.3.1"
+  url "https://go.kubebuilder.io/dl/#{version}/darwin/amd64"
+  sha256 "39314d45053b6c31eb17e35c9b8d923f8a38277a9a136448345dd4b7f0f308f4"
+
+  def install
+    bin.install "bin/kubebuilder"
+    (prefix/"assets").install Dir["bin/*"]
+  end
+
+  def caveats; <<~EOS
+    Additional kubebuilder components are installed in /usr/local/Cellar/kubebuilder/bin.
+    If you use tooling such as `envtest` you may want to add the following line to your profile or shell init script.
+    
+        export KUBEBUILDER_ASSETS="#{prefix}/assets"
+
+  EOS
+  end
+
+  test do
+    system "kubebuilder", "version"
+  end
+end


### PR DESCRIPTION
This change brings in a vendored kubebuilder installation
that includes the binary asset files required to use the built-in
testing functionalities of kubebuilder.

This version is newer than the one available in ``homebrew/homebrew-core``,
as that version does not appear to be tracking newer releases than ``v2.2.0``.

To install this formula you would need to run with an explicit path, e.g.
```bash
brew install gocardless/taps/kubebuilder
```