### PR TITLE
Calling GitHub.open_api is deprecated!

### DIFF
--- a/lib/gc/github_private_release_download_strategy.rb
+++ b/lib/gc/github_private_release_download_strategy.rb
@@ -67,7 +67,7 @@ module Gc
     def fetch_release_metadata
       release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/" \
                     "releases/tags/#{@tag}"
-      GitHub.open_api(release_url)
+      GitHub::API.open_rest(release_url)
     end
   end
 end


### PR DESCRIPTION
Use GitHub::API.open_rest instead.

Avoid the following error.

```
Error: Calling GitHub.open_api is deprecated! Use GitHub::API.open_rest instead.
Please report this issue to the gocardless/taps tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/gocardless/homebrew-taps/lib/gc/github_private_release_download_strategy.rb:70
```
