### PR TITLE
gocardless/expose-host-agent is a public repo now

### DIFF
--- a/Formula/expose-host-agent.rb
+++ b/Formula/expose-host-agent.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../lib/gc/github_private_release_download_strategy"
-
 class ExposeHostAgent < Formula
   desc "Wrapper command that exposes your local SSH agent for use during docker builds"
   homepage "https://github.com/gocardless/expose-host-agent"


### PR DESCRIPTION
... so we don't need the `github_private_release_download_strategy` anymore.