### PR TITLE
Drop warnings from yq's formula

### DIFF
--- a/Formula/yq@2.4.1.rb
+++ b/Formula/yq@2.4.1.rb
@@ -5,15 +5,14 @@ class YqAT241 < Formula
   sha256 "11fdf8269eb9eecd47398cb0d269a775492881ef53d880ef0d0e0daee26490d2"
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "7eef86b614ab9695cb8ba108a659cba5cd504211b7236f8a561c7619aaf9b792" => :catalina
-    sha256 "5bf8a07349fcb306261676187d53d684cd14cfafead1a120a95a6318bb8beda9" => :mojave
-    sha256 "750248b8af5a72505593466f7add52fd6e20a2c2556dd7e28fc756420618680d" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "7eef86b614ab9695cb8ba108a659cba5cd504211b7236f8a561c7619aaf9b792"
+    sha256 cellar: :any_skip_relocation, mojave:      "5bf8a07349fcb306261676187d53d684cd14cfafead1a120a95a6318bb8beda9"
+    sha256 cellar: :any_skip_relocation, high_sierra: "750248b8af5a72505593466f7add52fd6e20a2c2556dd7e28fc756420618680d"
   end
 
-  depends_on "go" => :build
+  keg_only :versioned_formula
 
-  conflicts_with "python-yq", :because => "both install `yq` executables"
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Seems like the latest version of homebrew is being picky, this is just
the result of running `brew style --fix` to remove the warnings.