### PR TITLE
Allow arm64 builds of gc-owner tap

### DIFF
--- a/Formula/gc-owners.rb
+++ b/Formula/gc-owners.rb
@@ -6,16 +6,20 @@ require_relative "../lib/gc/github_private_release_download_strategy"
 class GcOwners < Formula
   desc "GoCardless code ownership tool"
   homepage "https://github.com/gocardless/gc-owners"
-  version "0.1.2"
+  version "0.1.4"
   bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://github.com/gocardless/codeowners/releases/download/v0.1.2/codeowners_0.1.2_darwin_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy
-    sha256 "3518ee195faf478c99ea3c08d52a9e42f920e706514889524f9eba4d04b7983a"
+    url "https://github.com/gocardless/codeowners/releases/download/v0.1.4/codeowners_0.1.4_darwin_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy
+    sha256 "b2c158603352877ec581a8c6d87c3e4b5e979fb3e3fd3716ebe98d1157b94eb2"
+  end
+  if OS.mac? && Hardware::CPU.arm64?
+    url "https://github.com/gocardless/codeowners/releases/download/v0.1.4/codeowners_0.1.4_darwin_arm64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy
+    sha256 "d75f9232e8c821b45d2846696435f609980ad239c146a1905bc258ee109b875b"
   end
   if OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/gocardless/codeowners/releases/download/v0.1.2/codeowners_0.1.2_linux_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy
-    sha256 "79355f41429a431e09bc87249d490192f2a732a542fde94a3f392caf9e18fb14"
+    url "https://github.com/gocardless/codeowners/releases/download/v0.1.4/codeowners_0.1.4_linux_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy
+    sha256 "4647d3704d885b49ff723ecb325529a1246b720d4894aac7a84f82369b81f18b"
   end
 
   def install


### PR DESCRIPTION
Will need to update this when the code-owners project has a new release with the sha's corresponding to the right files.