### PR TITLE
Fix uninitialised constant error when install 404s

### DIFF
--- a/lib/gc/github_private_release_download_strategy.rb
+++ b/lib/gc/github_private_release_download_strategy.rb
@@ -46,7 +46,7 @@ module Gc
     def validate_github_repository_access!
       # Test access to the repository
       GitHub.repository(@owner, @repo)
-    rescue GitHub::HTTPNotFoundError
+    rescue GitHub::API::HTTPNotFoundError
       # We only handle HTTPNotFoundError here,
       # because AuthenticationFailedError is handled within util/github.
       message =


### PR DESCRIPTION
homebrew/brew recently namespaced this error under API which
led to blowing up unhelpfully instead of printing the helpful
error in the case of an invalid token.