### PR TITLE
Remove deprecated 'bottle :unneeded' lines

### DIFF
--- a/Formula/anu.rb
+++ b/Formula/anu.rb
@@ -7,7 +7,6 @@ class Anu < Formula
   desc "GoCardless Platform toolkit"
   homepage "https://github.com/gocardless/anu"
   version "27.9.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/crank.rb
+++ b/Formula/crank.rb
@@ -4,7 +4,6 @@ class Crank < Formula
   desc "GoCardless JSONSchema template generator"
   homepage "https://github.com/gocardless/crank"
   version "1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/crank/releases/download/va9b9cfe/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy

--- a/Formula/dispatcher.rb
+++ b/Formula/dispatcher.rb
@@ -4,7 +4,6 @@ class Dispatcher < Formula
   desc "Continuously dispatching deploys"
   homepage "https://github.com/gocardless/dispatcher"
   version "0.19.11"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/dispatcher/releases/download/v0.19.11/dispatcher_0.19.11_darwin_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy

--- a/Formula/gc-owners.rb
+++ b/Formula/gc-owners.rb
@@ -7,7 +7,6 @@ class GcOwners < Formula
   desc "GoCardless code ownership tool"
   homepage "https://github.com/gocardless/gc-owners"
   version "0.2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
'bottle :unneeded' is deprecated with no replacement, and no longer has any effect. This causes warnings when users update their homebrew formulae

Removing these lines is sufficient to fix it