### PR TITLE
Upgrade crank to v1b61d42

### DIFF
--- a/Formula/crank.rb
+++ b/Formula/crank.rb
@@ -3,7 +3,7 @@ require_relative "../lib/gc/github_private_release_download_strategy"
 class Crank < Formula
   desc "GoCardless JSONSchema template generator"
   homepage "https://github.com/gocardless/crank"
-  version "1"
+  version "2"
   bottle :unneeded
 
   if OS.mac?

--- a/Formula/crank.rb
+++ b/Formula/crank.rb
@@ -7,12 +7,12 @@ class Crank < Formula
   bottle :unneeded
 
   if OS.mac?
-    url "https://github.com/gocardless/crank/releases/download/vfa380ab/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
-    sha256 "025e3f4fdb7701eb72ce124fb76eb89fabebd29301b6a943b791ed432d7aef19"
+    url "https://github.com/gocardless/crank/releases/download/v1b61d42/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
+    sha256 "431b197d0ce53b903b92220ec68a97cdd035fdea6201bd24adf86e0d51f917fe"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/gocardless/crank/releases/download/vfa380ab/crank_linux_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
-      sha256 "51608ebc45067369c009d6fdf3d9de5c9c8bfe5c1bdcada94f0c94ed38df1592"
+      url "https://github.com/gocardless/crank/releases/download/v1b61d42/crank_linux_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
+      sha256 "ca99dadbaf025b61c365576bedfbcc8aea2026fc06db33b2fa018fa775f030da"
     end
   end
 


### PR DESCRIPTION
This PR upgrades crank to the latest version https://github.com/gocardless/crank/releases/tag/v1b61d42.

Upgrade to the latest version of Crank solves the issue of starting https://github.com/gocardless/developer.gocardless.com locally. 