### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/crank.rb
+++ b/Formula/crank.rb
@@ -4,7 +4,6 @@ class Crank < Formula
   desc "GoCardless JSONSchema template generator"
   homepage "https://github.com/gocardless/crank"
   version "2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/crank/releases/download/v1b61d42/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy

--- a/Formula/dispatcher.rb
+++ b/Formula/dispatcher.rb
@@ -4,7 +4,6 @@ class Dispatcher < Formula
   desc "Continuously dispatching deploys"
   homepage "https://github.com/gocardless/dispatcher"
   version "0.19.13"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/dispatcher/releases/download/v0.19.13/dispatcher_0.19.13_darwin_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy

--- a/Formula/draupnir.rb
+++ b/Formula/draupnir.rb
@@ -3,7 +3,6 @@ class Draupnir < Formula
   desc "Client for the draupnir database service"
   homepage ""
   version "5.2.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/draupnir/releases/download/v5.2.2/draupnir_5.2.2_darwin_amd64.tar.gz"


### PR DESCRIPTION
We're getting this warning on every `brew update`:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the gocardless/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/gocardless/homebrew-taps/Formula/draupnir.rb:6
```

`bottle :unneeded` was deprecated by homebrew-core in June 2021, and no
longer has any meaning (see https://github.com/Homebrew/brew/pull/11239)