### PR TITLE
Formula for goodhosts 1.1.0

### DIFF
--- a/Formula/goodhosts.rb
+++ b/Formula/goodhosts.rb
@@ -1,0 +1,22 @@
+class Goodhosts < Formula
+  desc "Simple hosts file management in a Go cli"
+  homepage "https://github.com/goodhosts/cli"
+  url "https://github.com/goodhosts/cli/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "6c956ffb6b9c838cd8e6dfe72b9e60fd8b21c674e57a0ad2fced7e23b042ce60"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args
+  end
+
+  test do
+    (testpath/"hosts").write <<~EOS
+      127.0.0.1 localhost
+    EOS
+
+    system bin/"goodhosts", "-f", testpath/"hosts", "a", "127.0.0.1", "localhost", "test.localhost"
+    assert_equal "127.0.0.1 localhost test.localhost", (testpath/"hosts").read.strip
+  end
+end


### PR DESCRIPTION
We recommend using goodhosts in the `payments-service` README to modify `/etc/hosts`. We add some GC-specific hostnames to localhost for convenience.

goodhosts' recommended installation process involves installing the go binary for your CPU architecture and placing it in `/usr/local/bin`. We could create a formula for goodhosts in our internal GC tap to make setting up the `payments-service` a bit easier. As we're also building the application from source, users don't need to worry about choosing the correct Go binary from the releases page.

Installation would then be:

```shell
brew tap gocardless/homebrew-taps
brew install goodhosts
```

I tried to add goodhosts to the core homebrew tap, but the maintainers closed the issue citing the project is too small, and advised to host it in another tap:

https://github.com/Homebrew/homebrew-core/pull/95450