### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/dispatcher.rb
+++ b/Formula/dispatcher.rb
@@ -4,7 +4,6 @@ class Dispatcher < Formula
   desc "Continuously dispatching deploys"
   homepage "https://github.com/gocardless/dispatcher"
   version "0.19.14"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/gocardless/dispatcher/releases/download/v0.19.14/dispatcher_0.19.14_darwin_amd64.tar.gz", :using => Gc::GithubPrivateReleaseDownloadStrategy


### PR DESCRIPTION
Heads-up @ivgiuliani as you touched this last in #39 – I saw an error when tapping this repo. Looks like it might need to be updated elsewhere for GoReleaser though 💙 