### PR TITLE
fix: point to correct repo for gc-owners tool

### DIFF
--- a/Formula/gc-owners.rb
+++ b/Formula/gc-owners.rb
@@ -5,7 +5,7 @@
 require_relative "../lib/gc/github_private_release_download_strategy"
 class GcOwners < Formula
   desc "GoCardless code ownership tool"
-  homepage "https://github.com/gocardless/gc-owners"
+  homepage "https://github.com/gocardless/codeowners"
   version "0.4.2"
 
   on_macos do


### PR DESCRIPTION
I used `brew info gc-owners` in an attempt to track down the repo for this tool and got the wrong link. Correcting it in this change.