### PR TITLE
Bump crank version

### DIFF
--- a/Formula/crank.rb
+++ b/Formula/crank.rb
@@ -6,12 +6,12 @@ class Crank < Formula
   version "2"
 
   if OS.mac?
-    url "https://github.com/gocardless/crank/releases/download/v1b61d42/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
-    sha256 "431b197d0ce53b903b92220ec68a97cdd035fdea6201bd24adf86e0d51f917fe"
+    url "https://github.com/gocardless/crank/releases/download/v26e1536/crank_darwin_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
+    sha256 "57070386320142d7548d225156a1e6a06e1abd9fc33f871b92737a33696ef161"
   elsif OS.linux?
     if Hardware::CPU.intel?
-      url "https://github.com/gocardless/crank/releases/download/v1b61d42/crank_linux_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
-      sha256 "ca99dadbaf025b61c365576bedfbcc8aea2026fc06db33b2fa018fa775f030da"
+      url "https://github.com/gocardless/crank/releases/download/v26e1536/crank_linux_amd64", :using => Gc::GithubPrivateReleaseDownloadStrategy
+      sha256 "98fe8dfadf9d9d1cec89db6a8a907b99846f6dff198e8bf725d528b32d7ce244"
     end
   end
 


### PR DESCRIPTION
Bump crank version to the latest release
https://github.com/gocardless/crank/releases